### PR TITLE
updated installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is a very small shard that provides a single macro, *defined?()*, which ret
    ```yaml
    dependencies:
      defined:
-       github: wyhaines/defined
+       github: wyhaines/defined.cr
    ```
 
 2. Run `shards install`


### PR DESCRIPTION
Updated the `github` line in the installation instruction from `wyhaines/defined` to `wyhaines/defined.cr`.

Without the `.cr` extension I get the following message when I run `shards install`
```
Resolving dependencies
Fetching https://github.com/wyhaines/defined.git
Failed to clone https://github.com/wyhaines/defined.git
```

I think this might be because of the name of the github repo?